### PR TITLE
Remove redundant "Modbus" prefixes.

### DIFF
--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 use byteorder::{BigEndian, ReadBytesExt};
-use {BitValue, ModbusResult, ModbusError};
+use {BitValue, Result, Error};
 
 pub fn unpack_bits(bytes: &[u8], count: u16) -> Vec<BitValue> {
     let mut res = Vec::with_capacity(count as usize);
@@ -43,11 +43,11 @@ pub fn unpack_bytes(data: &[u16]) -> Vec<u8> {
     res
 }
 
-pub fn pack_bytes(bytes: &[u8]) -> ModbusResult<Vec<u16>> {
+pub fn pack_bytes(bytes: &[u8]) -> Result<Vec<u16>> {
     let size = bytes.len();
     // check if we can create u16s from bytes by packing two u8s together without rest
     if size % 2 != 0 {
-        return Err(ModbusError::InvalidData);
+        return Err(Error::InvalidData);
     }
 
     let mut res = Vec::with_capacity(size / 2 + 1);

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,19 +1,19 @@
-use {ModbusResult, BitValue};
+use {Result, BitValue};
 
 pub trait Client {
-    fn read_discrete_inputs(&mut self, address: u16, quantity: u16) -> ModbusResult<Vec<BitValue>>;
+    fn read_discrete_inputs(&mut self, address: u16, quantity: u16) -> Result<Vec<BitValue>>;
 
-    fn read_coils(&mut self, address: u16, quantity: u16) -> ModbusResult<Vec<BitValue>>;
+    fn read_coils(&mut self, address: u16, quantity: u16) -> Result<Vec<BitValue>>;
 
-    fn write_single_coil(&mut self, address: u16, value: BitValue) -> ModbusResult<()>;
+    fn write_single_coil(&mut self, address: u16, value: BitValue) -> Result<()>;
 
-    fn write_multiple_coils(&mut self, address: u16, coils: &[BitValue]) -> ModbusResult<()>;
+    fn write_multiple_coils(&mut self, address: u16, coils: &[BitValue]) -> Result<()>;
 
-    fn read_input_registers(&mut self, address: u16, quantity: u16) -> ModbusResult<Vec<u16>>;
+    fn read_input_registers(&mut self, address: u16, quantity: u16) -> Result<Vec<u16>>;
 
-    fn read_holding_registers(&mut self, address: u16, quantity: u16) -> ModbusResult<Vec<u16>>;
+    fn read_holding_registers(&mut self, address: u16, quantity: u16) -> Result<Vec<u16>>;
 
-    fn write_single_register(&mut self, address: u16, value: u16) -> ModbusResult<()>;
+    fn write_single_register(&mut self, address: u16, value: u16) -> Result<()>;
 
-    fn write_multiple_registers(&mut self, address: u16, values: &[u16]) -> ModbusResult<()>;
+    fn write_multiple_registers(&mut self, address: u16, values: &[u16]) -> Result<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ impl<'a> Function<'a> {
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]
 /// Modbus exception codes returned from the server.
-pub enum ModbusExceptionCode {
+pub enum ExceptionCode {
     IllegalFunction         = 0x01,
     IllegalDataAddress      = 0x02,
     IllegalDataValue        = 0x03,
@@ -94,45 +94,45 @@ pub enum ModbusExceptionCode {
 
 /// Combination of Modbus, IO and data corruption errors
 #[derive(Debug)]
-pub enum ModbusError {
-    ModbusException(ModbusExceptionCode),
+pub enum Error {
+    Exception(ExceptionCode),
     Io(io::Error),
     InvalidResponse,
     InvalidData
 }
 
-impl From<ModbusExceptionCode> for ModbusError {
-    fn from(err: ModbusExceptionCode) -> ModbusError {
-        ModbusError::ModbusException(err)
+impl From<ExceptionCode> for Error {
+    fn from(err: ExceptionCode) -> Error {
+        Error::Exception(err)
     }
 }
 
-impl From<io::Error> for ModbusError {
-    fn from(err: io::Error) -> ModbusError {
-        ModbusError::Io(err)
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::Io(err)
     }
 }
 
-impl From<DecodingError> for ModbusError {
-    fn from(_err: DecodingError) -> ModbusError {
-        ModbusError::InvalidData
+impl From<DecodingError> for Error {
+    fn from(_err: DecodingError) -> Error {
+        Error::InvalidData
     }
 }
 
-impl From<EncodingError> for ModbusError {
-    fn from(_err: EncodingError) -> ModbusError {
-        ModbusError::InvalidData
+impl From<EncodingError> for Error {
+    fn from(_err: EncodingError) -> Error {
+        Error::InvalidData
     }
 }
 
-impl From<byteorder::Error> for ModbusError {
-    fn from(_err: byteorder::Error) -> ModbusError {
-        ModbusError::InvalidData
+impl From<byteorder::Error> for Error {
+    fn from(_err: byteorder::Error) -> Error {
+        Error::InvalidData
     }
 }
 
 /// Result type used to nofify success or failure in communication
-pub type ModbusResult<T> = std::result::Result<T, ModbusError>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 
 /// Single bit status values, used in read or write coil functions


### PR DESCRIPTION
Rust convention is to use namespaces to pun similar names. Before, for example, a user of this crate would write `modbus::ModbusResult`, instead of `modbus::Result`.