### PR TITLE
Fix header (de)serialization and implement std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,7 @@ keywords = ["modbus", "hardware"]
 [dependencies]
 enum_primitive = "0.1"
 num = "0.1"
-serde = "1.0"
-serde_derive = "1.0"
-bincode = "0.8"
-byteorder = "1.0"
+byteorder = "1.1"
 
 [dev-dependencies]
 modbus-test-server = {path = "test-server", version="0.0.*"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate num;
 extern crate byteorder;
 
 use std::io;
+use std::fmt;
 use std::str::FromStr;
 
 pub mod binary;
@@ -114,6 +115,46 @@ pub enum Error {
     InvalidData(Reason),
     InvalidFunction,
     ParseCoilError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+
+        use Error::*;
+
+        match *self {
+            Exception(ref code) => write!(f, "modbus exception: {:?}", code),
+            Io(ref err) => write!(f, "I/O error: {}", err),
+            InvalidResponse => write!(f, "invalid response"),
+            InvalidData(ref reason) => write!(f, "invalid data: {:?}", reason),
+            InvalidFunction => write!(f, "invalid modbus function"),
+            ParseCoilError => write!(f, "parse coil could not be parsed"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+
+        use Error::*;
+
+        match *self {
+            Exception(_) => "modbus exception",
+            Io(_) => "I/O error",
+            InvalidResponse => "invalid response",
+            InvalidData(_) => "invalid data",
+            InvalidFunction => "invalid modbus function",
+            ParseCoilError => "parse coil could not be parsed",
+        }
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+
+        match *self {
+            Error::Io(ref err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl From<ExceptionCode> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,6 @@
 #[macro_use]
 extern crate enum_primitive;
 extern crate num;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate bincode;
 extern crate byteorder;
 
 use std::io;
@@ -129,20 +125,6 @@ impl From<ExceptionCode> for Error {
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::Io(err)
-    }
-}
-
-impl From<bincode::Error> for Error {
-    fn from(err: bincode::Error) -> Error {
-        use bincode::ErrorKind::*;
-        use Error::InvalidData;
-        match *err {
-            InvalidEncoding { .. } => InvalidData(Reason::EncodingError),
-            IoError(err) => Error::Io(err),
-            SizeLimit => InvalidData(Reason::Custom("SizeLimit".into())),
-            SequenceMustHaveLength => InvalidData(Reason::Custom("SquenceMustHaveLength".into())),
-            Custom(msg) => InvalidData(Reason::Custom(msg)),
-        }
     }
 }
 


### PR DESCRIPTION
Version `v0.5.2` unfortunately suffers from an accident when we switched to `serde v1.0` and `bincode v0.8`: Bincode serializes the `Header` struct with `LittleEndian` but does not allow to switch to `BigEndian`.

So here is my proposal:
Don't use serde and bincode at all. At the moment these are dependencies that are way too big for just 7 bytes.

Moreover I implemented the `std::error::Error` trait to be able to chain them e.g. with `error_chain`.

I'd recommend to yank `v0.5.2` on crates.io because it's really broken.