### PR TITLE
Add support for changing the slave

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,4 +16,6 @@ pub trait Client {
     fn write_single_register(&mut self, address: u16, value: u16) -> Result<()>;
 
     fn write_multiple_registers(&mut self, address: u16, values: &[u16]) -> Result<()>;
+
+    fn set_uid(&mut self, uid: u8);
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -317,6 +317,11 @@ impl Client for Transport {
         let bytes = binary::unpack_bytes(values);
         self.write_multiple(&Function::WriteMultipleRegisters(addr, values.len() as u16, &bytes))
     }
+
+    /// Set the unit identifier.
+    fn set_uid(&mut self, uid: u8) {
+        self.uid = uid;
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
For ModbusTCP the slave is selected with the unit identifier.
Previously the unit identifier could only be specified once in the
configuration during creation of the client.