### PR TITLE
Use string for address to support leading 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Rust Modbus
+
 [![Rust](https://github.com/hirschenberger/modbus-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/hirschenberger/modbus-rs/actions/workflows/rust.yml)
 [![Crates.io](https://img.shields.io/crates/v/modbus)](https://crates.io/crates/modbus)
 [![docs.rs](https://img.shields.io/docsrs/modbus)](https://docs.rs/modbus/latest/modbus)
 [![Crates.io](https://img.shields.io/crates/d/modbus)](https://crates.io/crates/modbus)
 [![License](http://img.shields.io/:license-MIT-blue.svg)](http://doge.mit-license.org)
 
-
 Modbus implementation in pure Rust.
 
 ## Usage
+
 Add `modbus` to your `Cargo.toml` dependencies:
 
 ```toml
@@ -24,18 +25,19 @@ use modbus::tcp;
 
 let mut client = tcp::Transport::new("192.168.0.10");
 
-client.write_single_coil(1, Coil::On).unwrap();
-client.write_single_coil(3, Coil::On).unwrap();
+client.write_single_coil("1", Coil::On).unwrap();
+client.write_single_coil("3", Coil::On).unwrap();
 
-let res = client.read_coils(0, 5).unwrap();
+let res = client.read_coils("0", 5).unwrap();
 
 // res ==  vec![Coil::Off, Coil::On, Coil::Off, Coil::On, Coil::Off];
 ```
+
 See the [documentation](https://docs.rs/modbus/latest/modbus) for usage examples and further reference and
 the [examples](https://github.com/hirschenberger/modbus-rs/tree/master/examples) directory for a commandline client application.
 
-
 ## License
+
 Copyright © 2015-2026 Falco Hirschenberger
 
 Distributed under the [MIT License](LICENSE).

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -41,12 +41,12 @@ fn main() {
 
     if let Some(args) = matches.values_of("read-coils") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let qtty: u16 = args[1].parse().expect(matches.usage());
         println!("{:?}", client.read_coils(addr, qtty).expect("IO Error"));
     } else if let Some(args) = matches.values_of("read-discrete-inputs") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let qtty: u16 = args[1].parse().expect(matches.usage());
         println!(
             "{:?}",
@@ -54,12 +54,12 @@ fn main() {
         );
     } else if let Some(args) = matches.values_of("write-single-coil") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let value: Coil = args[1].parse().expect(matches.usage());
         client.write_single_coil(addr, value).expect("IO Error");
     } else if let Some(args) = matches.values_of("write-multiple-coils") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let values: Vec<Coil> = args[1]
             .split(',')
             .map(|s| s.trim().parse().expect(matches.usage()))
@@ -69,7 +69,7 @@ fn main() {
             .expect("IO Error");
     } else if let Some(args) = matches.values_of("read-holding-registers") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let qtty: u16 = args[1].parse().expect(matches.usage());
         println!(
             "{:?}",
@@ -77,12 +77,12 @@ fn main() {
         );
     } else if let Some(args) = matches.values_of("write-single-register") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let value: u16 = args[1].parse().expect(matches.usage());
         client.write_single_register(addr, value).expect("IO Error");
     } else if let Some(args) = matches.values_of("write-multiple-registers") {
         let args: Vec<&str> = args.collect();
-        let addr: u16 = args[0].parse().expect(matches.usage());
+        let addr: &str = args[0];
         let values: Vec<u16> = args[1]
             .split(',')
             .map(|s| s.trim().parse().expect(matches.usage()))

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,28 +1,28 @@
 use crate::{Coil, Result};
 
 pub trait Client {
-    fn read_discrete_inputs(&mut self, address: u16, quantity: u16) -> Result<Vec<Coil>>;
+    fn read_discrete_inputs(&mut self, address: &str, quantity: u16) -> Result<Vec<Coil>>;
 
-    fn read_coils(&mut self, address: u16, quantity: u16) -> Result<Vec<Coil>>;
+    fn read_coils(&mut self, address: &str, quantity: u16) -> Result<Vec<Coil>>;
 
-    fn write_single_coil(&mut self, address: u16, value: Coil) -> Result<()>;
+    fn write_single_coil(&mut self, address: &str, value: Coil) -> Result<()>;
 
-    fn write_multiple_coils(&mut self, address: u16, coils: &[Coil]) -> Result<()>;
+    fn write_multiple_coils(&mut self, address: &str, coils: &[Coil]) -> Result<()>;
 
-    fn read_input_registers(&mut self, address: u16, quantity: u16) -> Result<Vec<u16>>;
+    fn read_input_registers(&mut self, address: &str, quantity: u16) -> Result<Vec<u16>>;
 
-    fn read_holding_registers(&mut self, address: u16, quantity: u16) -> Result<Vec<u16>>;
+    fn read_holding_registers(&mut self, address: &str, quantity: u16) -> Result<Vec<u16>>;
 
-    fn write_single_register(&mut self, address: u16, value: u16) -> Result<()>;
+    fn write_single_register(&mut self, address: &str, value: u16) -> Result<()>;
 
-    fn write_multiple_registers(&mut self, address: u16, values: &[u16]) -> Result<()>;
+    fn write_multiple_registers(&mut self, address: &str, values: &[u16]) -> Result<()>;
 
     fn write_read_multiple_registers(
         &mut self,
-        write_address: u16,
+        write_address: &str,
         write_quantity: u16,
         write_values: &[u16],
-        read_address: u16,
+        read_address: &str,
         read_quantity: u16,
     ) -> Result<Vec<u16>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! let mut cfg = tcp::Config::default();
 //! # cfg.tcp_port = port;
 //! let mut client = tcp::Transport::new_with_cfg("127.0.0.1", cfg).unwrap();
-//! assert!(client.write_single_coil(0, Coil::On).is_ok());
+//! assert!(client.write_single_coil("0", Coil::On).is_ok());
 //! # }
 //! # }
 //! ```
@@ -39,20 +39,20 @@ pub use crate::client::Client;
 pub use crate::tcp::Config;
 pub use crate::tcp::Transport;
 
-type Address = u16;
+type Address<'a> = &'a str;
 type Quantity = u16;
 type Value = u16;
 
 enum Function<'a> {
-    ReadCoils(Address, Quantity),
-    ReadDiscreteInputs(Address, Quantity),
-    ReadHoldingRegisters(Address, Quantity),
-    ReadInputRegisters(Address, Quantity),
-    WriteSingleCoil(Address, Value),
-    WriteSingleRegister(Address, Value),
-    WriteMultipleCoils(Address, Quantity, &'a [u8]),
-    WriteMultipleRegisters(Address, Quantity, &'a [u8]),
-    WriteReadMultipleRegisters(Address, Quantity, &'a [u8], Address, Quantity),
+    ReadCoils(Address<'a>, Quantity),
+    ReadDiscreteInputs(Address<'a>, Quantity),
+    ReadHoldingRegisters(Address<'a>, Quantity),
+    ReadInputRegisters(Address<'a>, Quantity),
+    WriteSingleCoil(Address<'a>, Value),
+    WriteSingleRegister(Address<'a>, Value),
+    WriteMultipleCoils(Address<'a>, Quantity, &'a [u8]),
+    WriteMultipleRegisters(Address<'a>, Quantity, &'a [u8]),
+    WriteReadMultipleRegisters(Address<'a>, Quantity, &'a [u8], Address<'a>, Quantity),
 }
 
 impl<'a> Function<'a> {

--- a/src/scoped.rs
+++ b/src/scoped.rs
@@ -19,10 +19,10 @@
 //! # cfg.tcp_port = port;
 //! let mut client = tcp::Transport::new_with_cfg("127.0.0.1", cfg).unwrap();
 //! {
-//!    let mut auto = ScopedCoil::new(&mut client, 10, CoilDropFunction::On).unwrap();
-//!    assert_eq!(auto.mut_transport().read_coils(10, 1).unwrap(), vec![Coil::Off]);
+//!    let mut auto = ScopedCoil::new(&mut client, "10", CoilDropFunction::On).unwrap();
+//!    assert_eq!(auto.mut_transport().read_coils("10", 1).unwrap(), vec![Coil::Off]);
 //! }
-//! assert_eq!(client.read_coils(10, 1).unwrap(), vec![Coil::On]);
+//! assert_eq!(client.read_coils("10", 1).unwrap(), vec![Coil::On]);
 //! # }
 //! # }
 //! ```
@@ -44,13 +44,13 @@
 //! let mut cfg = tcp::Config::default();
 //! # cfg.tcp_port = port;
 //! let mut client = tcp::Transport::new_with_cfg("127.0.0.1", cfg).unwrap();
-//! client.write_single_register(10, 1);
+//! client.write_single_register("10", 1);
 //! {
 //!     let fun = |v| v + 5;
-//!     let mut auto = ScopedRegister::new(&mut client, 10, RegisterDropFunction::Fun(&fun)).unwrap();
-//!     assert_eq!(auto.mut_transport().read_holding_registers(10, 1).unwrap(), vec![1]);
+//!     let mut auto = ScopedRegister::new(&mut client, "10", RegisterDropFunction::Fun(&fun)).unwrap();
+//!     assert_eq!(auto.mut_transport().read_holding_registers("10", 1).unwrap(), vec![1]);
 //! }
-//! assert_eq!(client.read_holding_registers(10, 1).unwrap(), vec![6]);
+//! assert_eq!(client.read_holding_registers("10", 1).unwrap(), vec![6]);
 //! # }
 //! # }
 //! ```
@@ -84,7 +84,7 @@ pub enum RegisterDropFunction<'a> {
 /// Auto object which modifies it's coil value depending on a given modification function if it
 /// goes out of scope.
 pub struct ScopedCoil<'a> {
-    address: u16,
+    address: &'a str,
     fun: CoilDropFunction,
     transport: &'a mut Transport,
 }
@@ -111,10 +111,10 @@ impl<'a> ScopedCoil<'a> {
     /// Create a new `ScopedCoil` object with `address` and drop function when the object goes
     /// out of scope.
     pub fn new(
-        transport: &mut Transport,
-        address: u16,
+        transport: &'a mut Transport,
+        address: &'a str,
         fun: CoilDropFunction,
-    ) -> Result<ScopedCoil<'_>> {
+    ) -> Result<ScopedCoil<'a>> {
         Ok(ScopedCoil {
             address,
             fun,
@@ -130,7 +130,7 @@ impl<'a> ScopedCoil<'a> {
 /// Auto object which modifies it's register value depending on a given modification function if it
 /// goes out of scope.
 pub struct ScopedRegister<'a> {
-    address: u16,
+    address: &'a str,
     fun: RegisterDropFunction<'a>,
     transport: &'a mut Transport,
 }
@@ -162,7 +162,7 @@ impl<'a> ScopedRegister<'a> {
     /// out of scope.
     pub fn new<'b>(
         transport: &'b mut Transport,
-        address: u16,
+        address: &'b str,
         fun: RegisterDropFunction<'b>,
     ) -> Result<ScopedRegister<'b>> {
         Ok(ScopedRegister {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -129,29 +129,32 @@ impl Transport {
 
     fn read(&mut self, fun: &Function) -> Result<Vec<u8>> {
         let packed_size = |v: u16| v / 8 + if !v.is_multiple_of(8) { 1 } else { 0 };
-        let (addr, count, expected_bytes) = match *fun {
+        let (addr, count, expected_bytes) = match fun {
             Function::ReadCoils(a, c) | Function::ReadDiscreteInputs(a, c) => {
-                (a, c, packed_size(c) as usize)
+                (a, c, packed_size(*c) as usize)
             }
             Function::ReadHoldingRegisters(a, c) | Function::ReadInputRegisters(a, c) => {
-                (a, c, 2 * c as usize)
+                (a, c, 2 * (*c) as usize)
             }
             _ => return Err(Error::InvalidFunction),
         };
 
-        if count < 1 {
+        if *count < 1 {
             return Err(Error::InvalidData(Reason::RecvBufferEmpty));
         }
 
-        if count as usize > MODBUS_MAX_PACKET_SIZE {
+        if *count as usize > MODBUS_MAX_PACKET_SIZE {
             return Err(Error::InvalidData(Reason::UnexpectedReplySize));
         }
 
         let header = Header::new(self, MODBUS_HEADER_SIZE as u16 + 6u16);
         let mut buff = header.pack()?;
         buff.write_u8(fun.code())?;
-        buff.write_u16::<BigEndian>(addr)?;
-        buff.write_u16::<BigEndian>(count)?;
+        let addr_parsed: u16 = addr
+            .parse()
+            .map_err(|_| Error::InvalidData(Reason::DecodingError))?;
+        buff.write_u16::<BigEndian>(addr_parsed)?;
+        buff.write_u16::<BigEndian>(*count)?;
 
         match self.stream.write_all(&buff) {
             Ok(_s) => {
@@ -204,15 +207,18 @@ impl Transport {
     }
 
     fn write_single(&mut self, fun: &Function) -> Result<()> {
-        let (addr, value) = match *fun {
+        let (addr, value) = match fun {
             Function::WriteSingleCoil(a, v) | Function::WriteSingleRegister(a, v) => (a, v),
             _ => return Err(Error::InvalidFunction),
         };
 
         let mut buff = vec![0; MODBUS_HEADER_SIZE]; // Header gets filled in later
         buff.write_u8(fun.code())?;
-        buff.write_u16::<BigEndian>(addr)?;
-        buff.write_u16::<BigEndian>(value)?;
+        let addr_parsed: u16 = addr
+            .parse()
+            .map_err(|_| Error::InvalidData(Reason::DecodingError))?;
+        buff.write_u16::<BigEndian>(addr_parsed)?;
+        buff.write_u16::<BigEndian>(*value)?;
         self.write(&mut buff)
     }
 
@@ -223,9 +229,9 @@ impl Transport {
             write_values,
             read_addr,
             read_quantity,
-        ) = *fun
+        ) = fun
         {
-            let expected_bytes = 2 * read_quantity as usize;
+            let expected_bytes = 2 * (*read_quantity) as usize;
 
             let header = Header::new(
                 self,
@@ -234,12 +240,18 @@ impl Transport {
             let mut buff = header.pack()?;
 
             buff.write_u8(fun.code())?;
-            buff.write_u16::<BigEndian>(read_addr)?;
-            buff.write_u16::<BigEndian>(read_quantity)?;
-            buff.write_u16::<BigEndian>(write_addr)?;
-            buff.write_u16::<BigEndian>(write_quantity)?;
+            let read_addr_parsed: u16 = read_addr
+                .parse()
+                .map_err(|_| Error::InvalidData(Reason::DecodingError))?;
+            buff.write_u16::<BigEndian>(read_addr_parsed)?;
+            buff.write_u16::<BigEndian>(*read_quantity)?;
+            let write_addr_parsed: u16 = write_addr
+                .parse()
+                .map_err(|_| Error::InvalidData(Reason::DecodingError))?;
+            buff.write_u16::<BigEndian>(write_addr_parsed)?;
+            buff.write_u16::<BigEndian>(*write_quantity)?;
             buff.write_u8((write_values.len()) as u8)?;
-            for v in write_values {
+            for v in *write_values {
                 buff.write_u8(*v)?;
             }
 
@@ -264,7 +276,7 @@ impl Transport {
     }
 
     fn write_multiple(&mut self, fun: &Function) -> Result<()> {
-        let (addr, quantity, values) = match *fun {
+        let (addr, quantity, values) = match fun {
             Function::WriteMultipleCoils(a, q, v) | Function::WriteMultipleRegisters(a, q, v) => {
                 (a, q, v)
             }
@@ -273,10 +285,13 @@ impl Transport {
 
         let mut buff = vec![0; MODBUS_HEADER_SIZE]; // Header gets filled in later
         buff.write_u8(fun.code())?;
-        buff.write_u16::<BigEndian>(addr)?;
-        buff.write_u16::<BigEndian>(quantity)?;
+        let addr_parsed: u16 = addr
+            .parse()
+            .map_err(|_| Error::InvalidData(Reason::DecodingError))?;
+        buff.write_u16::<BigEndian>(addr_parsed)?;
+        buff.write_u16::<BigEndian>(*quantity)?;
         buff.write_u8(values.len() as u8)?;
-        for v in values {
+        for v in *values {
             buff.write_u8(*v)?;
         }
         self.write(&mut buff)
@@ -387,41 +402,41 @@ impl Transport {
 
 impl Client for Transport {
     /// Read `count` bits starting at address `addr`.
-    fn read_coils(&mut self, addr: u16, count: u16) -> Result<Vec<Coil>> {
+    fn read_coils(&mut self, addr: &str, count: u16) -> Result<Vec<Coil>> {
         let bytes = self.read(&Function::ReadCoils(addr, count))?;
         Ok(binary::unpack_bits(&bytes, count))
     }
 
     /// Read `count` input bits starting at address `addr`.
-    fn read_discrete_inputs(&mut self, addr: u16, count: u16) -> Result<Vec<Coil>> {
+    fn read_discrete_inputs(&mut self, addr: &str, count: u16) -> Result<Vec<Coil>> {
         let bytes = self.read(&Function::ReadDiscreteInputs(addr, count))?;
         Ok(binary::unpack_bits(&bytes, count))
     }
 
     /// Read `count` 16bit registers starting at address `addr`.
-    fn read_holding_registers(&mut self, addr: u16, count: u16) -> Result<Vec<u16>> {
+    fn read_holding_registers(&mut self, addr: &str, count: u16) -> Result<Vec<u16>> {
         let bytes = self.read(&Function::ReadHoldingRegisters(addr, count))?;
         binary::pack_bytes(&bytes[..])
     }
 
     /// Read `count` 16bit input registers starting at address `addr`.
-    fn read_input_registers(&mut self, addr: u16, count: u16) -> Result<Vec<u16>> {
+    fn read_input_registers(&mut self, addr: &str, count: u16) -> Result<Vec<u16>> {
         let bytes = self.read(&Function::ReadInputRegisters(addr, count))?;
         binary::pack_bytes(&bytes[..])
     }
 
     /// Write a single coil (bit) to address `addr`.
-    fn write_single_coil(&mut self, addr: u16, value: Coil) -> Result<()> {
+    fn write_single_coil(&mut self, addr: &str, value: Coil) -> Result<()> {
         self.write_single(&Function::WriteSingleCoil(addr, value.code()))
     }
 
     /// Write a single 16bit register to address `addr`.
-    fn write_single_register(&mut self, addr: u16, value: u16) -> Result<()> {
+    fn write_single_register(&mut self, addr: &str, value: u16) -> Result<()> {
         self.write_single(&Function::WriteSingleRegister(addr, value))
     }
 
     /// Write a multiple coils (bits) starting at address `addr`.
-    fn write_multiple_coils(&mut self, addr: u16, values: &[Coil]) -> Result<()> {
+    fn write_multiple_coils(&mut self, addr: &str, values: &[Coil]) -> Result<()> {
         let bytes = binary::pack_bits(values);
         self.write_multiple(&Function::WriteMultipleCoils(
             addr,
@@ -431,7 +446,7 @@ impl Client for Transport {
     }
 
     /// Write a multiple 16bit registers starting at address `addr`.
-    fn write_multiple_registers(&mut self, addr: u16, values: &[u16]) -> Result<()> {
+    fn write_multiple_registers(&mut self, addr: &str, values: &[u16]) -> Result<()> {
         let bytes = binary::unpack_bytes(values);
         self.write_multiple(&Function::WriteMultipleRegisters(
             addr,
@@ -443,10 +458,10 @@ impl Client for Transport {
     /// Write a multiple 16bit registers starting at address `write_addr` and read starting at address `read_addr`.
     fn write_read_multiple_registers(
         &mut self,
-        write_address: u16,
+        write_address: &str,
         write_quantity: u16,
         write_values: &[u16],
-        read_address: u16,
+        read_address: &str,
         read_quantity: u16,
     ) -> Result<Vec<u16>> {
         let write_bytes = binary::unpack_bytes(write_values);


### PR DESCRIPTION
I have a device where I have to read a holding register at address 0002. This was not supported by modbus-rs. With this pull request, the address is changed to a String so that leading zeros are supported.